### PR TITLE
Add Support for OpenZeppelin 3

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -3,14 +3,14 @@ version = 1
 
 [[package]]
 name = "openzeppelin"
-version = "2.0.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:5e4fdecc957cfca7854d95912dc72d9f725517c063b116512900900add29fd77"
+version = "3.0.0-alpha.2"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts?branch=release-v3.0.0-alpha.2#0e51722f231c0913915945d3df89e43cbb5cfc38"
 dependencies = [
  "openzeppelin_access",
  "openzeppelin_account",
  "openzeppelin_finance",
  "openzeppelin_governance",
+ "openzeppelin_interfaces",
  "openzeppelin_introspection",
  "openzeppelin_merkle_tree",
  "openzeppelin_presets",
@@ -22,67 +22,73 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_access"
-version = "2.0.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:511681dd26d814ee2bc996d44ff8cb4aaa5ae9d14272130def7eb901cf004850"
+version = "3.0.0-alpha.2"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts?branch=release-v3.0.0-alpha.2#0e51722f231c0913915945d3df89e43cbb5cfc38"
 dependencies = [
+ "openzeppelin_interfaces",
  "openzeppelin_introspection",
 ]
 
 [[package]]
 name = "openzeppelin_account"
-version = "2.0.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:fb3381c50d68b028d3801feb43df378e2bd62137b6884844f8f60aefe796188b"
+version = "3.0.0-alpha.2"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts?branch=release-v3.0.0-alpha.2#0e51722f231c0913915945d3df89e43cbb5cfc38"
 dependencies = [
+ "openzeppelin_interfaces",
  "openzeppelin_introspection",
  "openzeppelin_utils",
 ]
 
 [[package]]
 name = "openzeppelin_finance"
-version = "2.0.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:e9456ef69502a87c4c99bf50145351b50950f8b11244847d92935c466c4ba787"
+version = "3.0.0-alpha.2"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts?branch=release-v3.0.0-alpha.2#0e51722f231c0913915945d3df89e43cbb5cfc38"
 dependencies = [
  "openzeppelin_access",
+ "openzeppelin_interfaces",
  "openzeppelin_token",
 ]
 
 [[package]]
 name = "openzeppelin_governance"
-version = "2.0.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:056e6d6f3d48193b53f06283884f8a9675f986fc85425f6a40e8c1aeb3b3ecfa"
+version = "3.0.0-alpha.2"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts?branch=release-v3.0.0-alpha.2#0e51722f231c0913915945d3df89e43cbb5cfc38"
 dependencies = [
  "openzeppelin_access",
  "openzeppelin_account",
+ "openzeppelin_interfaces",
  "openzeppelin_introspection",
  "openzeppelin_token",
  "openzeppelin_utils",
 ]
 
 [[package]]
+name = "openzeppelin_interfaces"
+version = "2.1.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts?branch=release-v3.0.0-alpha.2#0e51722f231c0913915945d3df89e43cbb5cfc38"
+
+[[package]]
 name = "openzeppelin_introspection"
-version = "2.0.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:87773ed6cd2318f169283ecbbb161890d1996260a80302d81ec45b70ee5e54c1"
+version = "3.0.0-alpha.2"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts?branch=release-v3.0.0-alpha.2#0e51722f231c0913915945d3df89e43cbb5cfc38"
+dependencies = [
+ "openzeppelin_interfaces",
+]
 
 [[package]]
 name = "openzeppelin_merkle_tree"
-version = "2.0.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:47f80c9ce59557774243214f8e75c5e866f30f3d8daa755855f6ffd01c89ca89"
+version = "3.0.0-alpha.2"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts?branch=release-v3.0.0-alpha.2#0e51722f231c0913915945d3df89e43cbb5cfc38"
 
 [[package]]
 name = "openzeppelin_presets"
-version = "2.0.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:36c761ee923f1dc0887c0eab8c224b49ac242dbfe9163fbb0b08562042ab3d98"
+version = "3.0.0-alpha.2"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts?branch=release-v3.0.0-alpha.2#0e51722f231c0913915945d3df89e43cbb5cfc38"
 dependencies = [
  "openzeppelin_access",
  "openzeppelin_account",
  "openzeppelin_finance",
+ "openzeppelin_interfaces",
  "openzeppelin_introspection",
  "openzeppelin_token",
  "openzeppelin_upgrades",
@@ -91,33 +97,36 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_security"
-version = "2.0.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:902932ec296c2f400e0ac7c579edeaafd6067b6ce6d9854c1191de28e396ffe3"
+version = "3.0.0-alpha.2"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts?branch=release-v3.0.0-alpha.2#0e51722f231c0913915945d3df89e43cbb5cfc38"
+dependencies = [
+ "openzeppelin_interfaces",
+]
 
 [[package]]
 name = "openzeppelin_token"
-version = "2.0.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:6fe61f63b5a6706018265fb7373b6e5bd3ff829bdc760b2b90296b1e708d180c"
+version = "3.0.0-alpha.2"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts?branch=release-v3.0.0-alpha.2#0e51722f231c0913915945d3df89e43cbb5cfc38"
 dependencies = [
  "openzeppelin_access",
  "openzeppelin_account",
+ "openzeppelin_interfaces",
  "openzeppelin_introspection",
  "openzeppelin_utils",
 ]
 
 [[package]]
 name = "openzeppelin_upgrades"
-version = "2.0.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:560d57a9c3f3ec5a476e82fec8963c93c8df63a4ff9ff134f64ab8383bde3c61"
+version = "3.0.0-alpha.2"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts?branch=release-v3.0.0-alpha.2#0e51722f231c0913915945d3df89e43cbb5cfc38"
 
 [[package]]
 name = "openzeppelin_utils"
-version = "2.0.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:bf799c794139837f397975ffdf6a7ed5032d198bbf70e87a8f44f144a9dfc505"
+version = "3.0.0-alpha.2"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts?branch=release-v3.0.0-alpha.2#0e51722f231c0913915945d3df89e43cbb5cfc38"
+dependencies = [
+ "openzeppelin_interfaces",
+]
 
 [[package]]
 name = "snforge_scarb_plugin"

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -19,7 +19,7 @@ keywords = [
 
 [workspace.dependencies]
 starknet = "2.12.0"
-openzeppelin = "2.0.0"
+openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts", branch = "release-v3.0.0-alpha.2" }
 snforge_std = "0.48.0"
 assert_macros = "2.12.0"
 

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -19,7 +19,7 @@ keywords = [
 
 [workspace.dependencies]
 starknet = "2.12.0"
-openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts", tag = "release-v3.0.0-alpha.2" }
+openzeppelin = openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts", commit = "fc942069996633e13f11de0710c586b7d2ed8df7" }
 snforge_std = "0.48.0"
 assert_macros = "2.12.0"
 

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -19,7 +19,7 @@ keywords = [
 
 [workspace.dependencies]
 starknet = "2.12.0"
-openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts", branch = "release-v3.0.0-alpha.2" }
+openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts", tag = "release-v3.0.0-alpha.2" }
 snforge_std = "0.48.0"
 assert_macros = "2.12.0"
 

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -19,7 +19,7 @@ keywords = [
 
 [workspace.dependencies]
 starknet = "2.12.0"
-openzeppelin = openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts", commit = "fc942069996633e13f11de0710c586b7d2ed8df7" }
+openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts", commit = "fc942069996633e13f11de0710c586b7d2ed8df7" }
 snforge_std = "0.48.0"
 assert_macros = "2.12.0"
 

--- a/packages/testing/src/test_utils.cairo
+++ b/packages/testing/src/test_utils.cairo
@@ -1,5 +1,5 @@
 use core::fmt::Debug;
-use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
+use openzeppelin::interfaces::token::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
 use snforge_std::byte_array::try_deserialize_bytearray_error;
 use snforge_std::cheatcodes::events::Event;
 use snforge_std::{

--- a/packages/utils/src/components/blocklist/tests.cairo
+++ b/packages/utils/src/components/blocklist/tests.cairo
@@ -1,4 +1,4 @@
-use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
+use openzeppelin::interfaces::token::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
 use snforge_std::{
     ContractClassTrait, DeclareResultTrait, EventSpyAssertionsTrait, declare, spy_events,
 };

--- a/packages/utils/src/components/deposit/deposit.cairo
+++ b/packages/utils/src/components/deposit/deposit.cairo
@@ -4,7 +4,7 @@ pub(crate) mod Deposit {
     use core::num::traits::Zero;
     use core::panic_with_felt252;
     use core::pedersen::PedersenTrait;
-    use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
+    use openzeppelin::interfaces::token::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use starknet::storage::{
         Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
         StoragePointerWriteAccess,

--- a/packages/utils/src/components/roles/roles.cairo
+++ b/packages/utils/src/components/roles/roles.cairo
@@ -45,7 +45,7 @@ pub(crate) mod RolesComponent {
     use openzeppelin::access::accesscontrol::AccessControlComponent::{
         AccessControlImpl, InternalTrait as AccessInternalTrait,
     };
-    use openzeppelin::access::accesscontrol::interface::IAccessControl;
+    use openzeppelin::interfaces::access::accesscontrol::IAccessControl;
     use openzeppelin::introspection::src5::SRC5Component;
 
     #[embeddable_as(RolesImpl)]

--- a/packages/utils/src/erc20/erc20_mocks.cairo
+++ b/packages/utils/src/erc20/erc20_mocks.cairo
@@ -41,7 +41,7 @@ pub(crate) mod DualCaseERC20Mock {
 
 #[starknet::contract]
 mod ERC20DecimalsMock {
-    use openzeppelin::token::erc20::interface::IERC20Metadata;
+    use openzeppelin::interfaces::token::erc20::IERC20Metadata;
     use openzeppelin::token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
     use starknet::ContractAddress;
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};

--- a/packages/utils/src/erc20/erc20_utils.cairo
+++ b/packages/utils/src/erc20/erc20_utils.cairo
@@ -1,4 +1,4 @@
-use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
+use openzeppelin::interfaces::token::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
 use starknet::{ContractAddress, get_contract_address};
 
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starkware-starknet-utils/110)
<!-- Reviewable:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrade OpenZeppelin to v3.0.0-alpha.2 (git source) and migrate import paths to the new `openzeppelin::interfaces` module across ERC20 and access control usages.
> 
> - **Dependencies**:
>   - Upgrade `openzeppelin` from `2.0.0` (registry) to `3.0.0-alpha.2` (git) in `Scarb.toml` and `Scarb.lock`.
>   - Add `openzeppelin_interfaces` package and update subpackages to v3 alpha.
> - **Code updates (imports)**:
>   - Replace `openzeppelin::token::erc20::interface::*` with `openzeppelin::interfaces::token::erc20::*` in:
>     - `packages/testing/src/test_utils.cairo`
>     - `packages/utils/src/components/blocklist/tests.cairo`
>     - `packages/utils/src/components/deposit/deposit.cairo`
>     - `packages/utils/src/erc20/erc20_utils.cairo`
>   - Replace `openzeppelin::access::accesscontrol::interface::IAccessControl` with `openzeppelin::interfaces::access::accesscontrol::IAccessControl` in `packages/utils/src/components/roles/roles.cairo`.
>   - Update `IERC20Metadata` import to `openzeppelin::interfaces::token::erc20::IERC20Metadata` in `packages/utils/src/erc20/erc20_mocks.cairo`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6624068f0f58a112f11568815d7a85c634ef974b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->