### PR TITLE
chore(utils): update deps versions

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -13,10 +13,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: foundry-rs/setup-snfoundry@v3
         with:
-          starknet-foundry-version: "0.48.0"
+          starknet-foundry-version: "0.49.0"
       - uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: "2.12.0"
+          scarb-version: "2.12.2"
 
       - name: Install cairo-coverage
         run: |

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-scarb 2.12.1
-starknet-foundry 0.48.1
+scarb 2.12.2
+starknet-foundry 0.49.0

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -121,15 +121,15 @@ checksum = "sha256:bf799c794139837f397975ffdf6a7ed5032d198bbf70e87a8f44f144a9dfc
 
 [[package]]
 name = "snforge_scarb_plugin"
-version = "0.48.0"
+version = "0.49.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:8630dcf3fa4df36a3d45e6a2d053cf84c548ab154e829fece99373ae5852921c"
+checksum = "sha256:903150f0e9542e4277d417029eea4c03af0db398b581f9f7ae3ebbdac9afc657"
 
 [[package]]
 name = "snforge_std"
-version = "0.48.0"
+version = "0.49.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:981139c83359089540652c44f4a1a888c77409eedaa148377927cc63a604b67b"
+checksum = "sha256:73d73653cc4356ec51b92a6bec9d8385b20318170c2f2ade7891e5185a0e7e64"
 dependencies = [
  "snforge_scarb_plugin",
 ]

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -18,10 +18,10 @@ keywords = [
 
 
 [workspace.dependencies]
-starknet = "2.12.0"
+starknet = "2.12.2"
 openzeppelin = "2.0.0"
-snforge_std = "0.48.0"
-assert_macros = "2.12.0"
+snforge_std = "0.49.0"
+assert_macros = "2.12.2"
 
 
 [workspace.tool.fmt]
@@ -34,3 +34,4 @@ allow-prebuilt-plugins = ["snforge_std"]
 unstable-add-statements-functions-debug-info = true
 unstable-add-statements-code-locations-debug-info = true
 inlining-strategy = "avoid"
+panic-backtrace = true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps StarkNet/Scarb/snforge versions across workspace, CI, and lockfile, and enables panic backtraces in dev profile.
> 
> - **Dependencies**:
>   - Bump `starknet` to `2.12.2`, `snforge_std` to `0.49.0`, and `assert_macros` to `2.12.2` in `Scarb.toml`.
>   - Update lockfile: `snforge_scarb_plugin` and `snforge_std` to `0.49.0` in `Scarb.lock`.
> - **CI/Tooling**:
>   - Update CI workflow `.github/workflows/on-pull-request.yaml` to use `starknet-foundry 0.49.0` and `scarb 2.12.2`.
>   - Sync `.tool-versions` to `scarb 2.12.2` and `starknet-foundry 0.49.0`.
> - **Config**:
>   - Enable `panic-backtrace = true` under `[profile.dev.cairo]` in `Scarb.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 643aeddc84232de75835368cb46a06ec918d5fed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starkware-starknet-utils/116)
<!-- Reviewable:end -->
