### PR TITLE
feat: add allowance method to token trait

### DIFF
--- a/packages/testing/src/test_utils.cairo
+++ b/packages/testing/src/test_utils.cairo
@@ -263,24 +263,30 @@ pub trait TokenTrait<TTokenState> {
     fn fund(self: TTokenState, recipient: ContractAddress, amount: u128);
     fn approve(self: TTokenState, owner: ContractAddress, spender: ContractAddress, amount: u128);
     fn balance_of(self: TTokenState, account: ContractAddress) -> u128;
+    fn allowance(self: TTokenState, owner: ContractAddress, spender: ContractAddress) -> u128;
 }
 
 pub impl TokenImpl of TokenTrait<TokenState> {
     fn fund(self: TokenState, recipient: ContractAddress, amount: u128) {
         let erc20_dispatcher = IERC20Dispatcher { contract_address: self.address };
         cheat_caller_address_once(contract_address: self.address, caller_address: self.owner);
-        erc20_dispatcher.transfer(recipient: recipient, amount: amount.into());
+        erc20_dispatcher.transfer(:recipient, amount: amount.into());
     }
 
     fn approve(self: TokenState, owner: ContractAddress, spender: ContractAddress, amount: u128) {
         let erc20_dispatcher = IERC20Dispatcher { contract_address: self.address };
         cheat_caller_address_once(contract_address: self.address, caller_address: owner);
-        erc20_dispatcher.approve(spender: spender, amount: amount.into());
+        erc20_dispatcher.approve(:spender, amount: amount.into());
     }
 
     fn balance_of(self: TokenState, account: ContractAddress) -> u128 {
         let erc20_dispatcher = IERC20Dispatcher { contract_address: self.address };
-        erc20_dispatcher.balance_of(account: account).try_into().unwrap()
+        erc20_dispatcher.balance_of(:account).try_into().unwrap()
+    }
+
+    fn allowance(self: TokenState, owner: ContractAddress, spender: ContractAddress) -> u128 {
+        let erc20_dispatcher = IERC20Dispatcher { contract_address: self.address };
+        erc20_dispatcher.allowance(:owner, :spender).try_into().unwrap()
     }
 }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starkware-starknet-utils/159)
<!-- Reviewable:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small testing-utility API extension and minor call-site syntax tweaks, with no production logic or security-sensitive code touched.
> 
> **Overview**
> Extends the testing `TokenTrait` in `test_utils.cairo` with an `allowance(owner, spender)` helper and implements it via `IERC20Dispatcher.allowance`.
> 
> Also updates existing ERC20 dispatcher calls (`transfer`, `approve`, `balance_of`) to use Cairo’s shorthand named-argument syntax for consistency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ac6c4099c17fe7925924bd9951b5046c3f9fff0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->