### PR TITLE
fix: move allowance method to correct impl

### DIFF
--- a/packages/testing/src/test_utils.cairo
+++ b/packages/testing/src/test_utils.cairo
@@ -263,7 +263,6 @@ pub trait TokenTrait<TTokenState> {
     fn fund(self: TTokenState, recipient: ContractAddress, amount: u128);
     fn approve(self: TTokenState, owner: ContractAddress, spender: ContractAddress, amount: u128);
     fn balance_of(self: TTokenState, account: ContractAddress) -> u128;
-    fn allowance(self: TTokenState, owner: ContractAddress, spender: ContractAddress) -> u128;
 }
 
 pub impl TokenImpl of TokenTrait<TokenState> {
@@ -282,11 +281,6 @@ pub impl TokenImpl of TokenTrait<TokenState> {
     fn balance_of(self: TokenState, account: ContractAddress) -> u128 {
         let erc20_dispatcher = IERC20Dispatcher { contract_address: self.address };
         erc20_dispatcher.balance_of(:account).try_into().unwrap()
-    }
-
-    fn allowance(self: TokenState, owner: ContractAddress, spender: ContractAddress) -> u128 {
-        let erc20_dispatcher = IERC20Dispatcher { contract_address: self.address };
-        erc20_dispatcher.allowance(:owner, :spender).try_into().unwrap()
     }
 }
 
@@ -326,5 +320,9 @@ pub impl TokenHelperImpl of TokenHelperTrait {
         self: @Token, sender: ContractAddress, recipient: ContractAddress, amount: u256,
     ) {
         checked_transfer_from(token_address: self.contract_address(), :sender, :recipient, :amount);
+    }
+
+    fn allowance(self: @Token, owner: ContractAddress, spender: ContractAddress) -> u256 {
+        IERC20Dispatcher { contract_address: self.contract_address() }.allowance(:owner, :spender)
     }
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starkware-starknet-utils/160)
<!-- Reviewable:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small refactor in testing utilities moving an ERC20 `allowance` helper and changing its return type to match the `Token` helper API.
> 
> **Overview**
> Moves the ERC20 `allowance` helper out of the `TokenTrait<TokenState>` test wrapper (and removes its `u128`-typed implementation) and adds `allowance(owner, spender) -> u256` to the `TokenHelperImpl` generated trait for `snforge_std::Token`.
> 
> This aligns allowance queries with the rest of the `Token` helper methods and avoids exposing allowance on the mock `TokenState` helper API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8de1d7dd6358ad751a5cd1ca2c1346824768fbfc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->