### PR TITLE
ci: bump codecov-action to v7.0.0

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Run test and coverage
         run: scarb test -w --coverage
 
-      - uses: codecov/codecov-action@v5.3.1
+      - uses: codecov/codecov-action@v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: packages/utils/coverage/coverage.lcov


### PR DESCRIPTION
## Problem

CI fails on the `codecov/codecov-action@v5.3.1` step (tests themselves pass):

\`\`\`
gpg: no valid OpenPGP data found.
gpg: Can't check signature: No public key
==> Could not verify signature. Please contact Codecov if problem continues
##[error]Process completed with exit code 1.
\`\`\`

## Root cause

Codecov lost control of their old Keybase account (\`codecovsecurity\`) and migrated their CLI signing key to a new account (\`codecovsecops\`). \`codecov-action@v5.3.1\` still fetches the key from the old, broken location, so the GPG key import fails and signature verification of the downloaded CLI binary fails.

## Fix

Bump \`codecov/codecov-action\` to \`v7.0.0\`, which republishes with the corrected signing key so GPG verification works again. \`fail_ci_if_error: true\` is kept so genuine upload failures still surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starkware-starknet-utils/170)
<!-- Reviewable:end -->
