### PR TITLE
refactor: rename ISubAccount execute to owner_execute

### DIFF
--- a/packages/utils/src/contracts/sub_account.cairo
+++ b/packages/utils/src/contracts/sub_account.cairo
@@ -5,8 +5,8 @@ pub trait ISubAccount<TContractState> {
     /// Executes the given `calls` exactly as an account contract would, and returns the
     /// return value of each call. Only the owner (the deployer) is authorized to call this
     /// entrypoint.
-    fn execute(ref self: TContractState, calls: Array<Call>) -> Array<Span<felt252>>;
-    /// Returns the address authorized to call `execute`.
+    fn sub_account_execute(ref self: TContractState, calls: Array<Call>) -> Array<Span<felt252>>;
+    /// Returns the address authorized to call `sub_account_execute`.
     fn owner(self: @TContractState) -> starknet::ContractAddress;
     // TODO: Consider adding ownership transfer entrypoint.
 }
@@ -31,7 +31,9 @@ pub mod SubAccount {
 
     #[abi(embed_v0)]
     impl SubAccountImpl of ISubAccount<ContractState> {
-        fn execute(ref self: ContractState, calls: Array<Call>) -> Array<Span<felt252>> {
+        fn sub_account_execute(
+            ref self: ContractState, calls: Array<Call>,
+        ) -> Array<Span<felt252>> {
             assert(get_caller_address() == self.owner(), 'SUB_ACCOUNT: NOT OWNER');
             execute_calls(calls.span())
         }

--- a/packages/utils/src/contracts/sub_account.cairo
+++ b/packages/utils/src/contracts/sub_account.cairo
@@ -5,8 +5,8 @@ pub trait ISubAccount<TContractState> {
     /// Executes the given `calls` exactly as an account contract would, and returns the
     /// return value of each call. Only the owner (the deployer) is authorized to call this
     /// entrypoint.
-    fn sub_account_execute(ref self: TContractState, calls: Array<Call>) -> Array<Span<felt252>>;
-    /// Returns the address authorized to call `sub_account_execute`.
+    fn owner_execute(ref self: TContractState, calls: Array<Call>) -> Array<Span<felt252>>;
+    /// Returns the address authorized to call `owner_execute`.
     fn owner(self: @TContractState) -> starknet::ContractAddress;
     // TODO: Consider adding ownership transfer entrypoint.
 }
@@ -31,7 +31,7 @@ pub mod SubAccount {
 
     #[abi(embed_v0)]
     impl SubAccountImpl of ISubAccount<ContractState> {
-        fn sub_account_execute(
+        fn owner_execute(
             ref self: ContractState, calls: Array<Call>,
         ) -> Array<Span<felt252>> {
             assert(get_caller_address() == self.owner(), 'SUB_ACCOUNT: NOT OWNER');

--- a/packages/utils/src/contracts/test_sub_account.cairo
+++ b/packages/utils/src/contracts/test_sub_account.cairo
@@ -84,7 +84,7 @@ mod SubAccountTests {
         cheat_caller_address_once(
             contract_address: sub_account.contract_address, caller_address: OWNER,
         );
-        sub_account.sub_account_execute(array![call]);
+        sub_account.owner_execute(array![call]);
 
         assert!(target.get_value() == 42);
     }
@@ -101,7 +101,7 @@ mod SubAccountTests {
         cheat_caller_address_once(
             contract_address: sub_account.contract_address, caller_address: OWNER,
         );
-        let mut results = sub_account.sub_account_execute(array![call]);
+        let mut results = sub_account.owner_execute(array![call]);
 
         assert!(results.len() == 1);
         let mut ret = *results.at(0);
@@ -128,7 +128,7 @@ mod SubAccountTests {
         cheat_caller_address_once(
             contract_address: sub_account.contract_address, caller_address: OWNER,
         );
-        sub_account.sub_account_execute(array![first, second]);
+        sub_account.owner_execute(array![first, second]);
 
         // The last call wins, proving calls run sequentially in the given order.
         assert!(target.get_value() == 2);
@@ -141,7 +141,7 @@ mod SubAccountTests {
         cheat_caller_address_once(
             contract_address: sub_account.contract_address, caller_address: OWNER,
         );
-        let results = sub_account.sub_account_execute(array![]);
+        let results = sub_account.owner_execute(array![]);
 
         assert!(results.len() == 0);
     }
@@ -164,9 +164,9 @@ mod SubAccountTests {
         cheat_caller_address_once(
             contract_address: sub_account.contract_address, caller_address: OTHER,
         );
-        match safe_sub_account.sub_account_execute(array![call]) {
+        match safe_sub_account.owner_execute(array![call]) {
             Result::Ok(_) => panic!(
-                "Expected sub_account_execute to panic for unauthorized caller",
+                "Expected owner_execute to panic for unauthorized caller",
             ),
             Result::Err(panic_data) => { assert!(*panic_data.at(0) == 'SUB_ACCOUNT: NOT OWNER'); },
         }

--- a/packages/utils/src/contracts/test_sub_account.cairo
+++ b/packages/utils/src/contracts/test_sub_account.cairo
@@ -84,7 +84,7 @@ mod SubAccountTests {
         cheat_caller_address_once(
             contract_address: sub_account.contract_address, caller_address: OWNER,
         );
-        sub_account.execute(array![call]);
+        sub_account.sub_account_execute(array![call]);
 
         assert!(target.get_value() == 42);
     }
@@ -101,7 +101,7 @@ mod SubAccountTests {
         cheat_caller_address_once(
             contract_address: sub_account.contract_address, caller_address: OWNER,
         );
-        let mut results = sub_account.execute(array![call]);
+        let mut results = sub_account.sub_account_execute(array![call]);
 
         assert!(results.len() == 1);
         let mut ret = *results.at(0);
@@ -128,7 +128,7 @@ mod SubAccountTests {
         cheat_caller_address_once(
             contract_address: sub_account.contract_address, caller_address: OWNER,
         );
-        sub_account.execute(array![first, second]);
+        sub_account.sub_account_execute(array![first, second]);
 
         // The last call wins, proving calls run sequentially in the given order.
         assert!(target.get_value() == 2);
@@ -141,7 +141,7 @@ mod SubAccountTests {
         cheat_caller_address_once(
             contract_address: sub_account.contract_address, caller_address: OWNER,
         );
-        let results = sub_account.execute(array![]);
+        let results = sub_account.sub_account_execute(array![]);
 
         assert!(results.len() == 0);
     }
@@ -164,8 +164,10 @@ mod SubAccountTests {
         cheat_caller_address_once(
             contract_address: sub_account.contract_address, caller_address: OTHER,
         );
-        match safe_sub_account.execute(array![call]) {
-            Result::Ok(_) => panic!("Expected execute to panic for unauthorized caller"),
+        match safe_sub_account.sub_account_execute(array![call]) {
+            Result::Ok(_) => panic!(
+                "Expected sub_account_execute to panic for unauthorized caller",
+            ),
             Result::Err(panic_data) => { assert!(*panic_data.at(0) == 'SUB_ACCOUNT: NOT OWNER'); },
         }
     }


### PR DESCRIPTION
## Summary
Renames the `execute` entrypoint in `ISubAccount` to `owner_execute` to avoid ambiguity with account-contract `execute` semantics. The name reflects the authorization rule: only the `owner` (the deployer) may call it.

## Changes
- Trait declaration + impl in `sub_account.cairo`
- Updated doc comments
- All call sites in `test_sub_account.cairo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starkware-starknet-utils/171)
<!-- Reviewable:end -->
