### PR TITLE
feat(utils): add EICUpgradableComponent

### DIFF
--- a/packages/utils/src/components.cairo
+++ b/packages/utils/src/components.cairo
@@ -1,6 +1,7 @@
 pub mod blocklist;
 pub mod common_roles;
 pub mod deposit;
+pub mod eic_upgradable;
 pub mod nonce;
 pub mod pausable;
 pub mod replaceability;

--- a/packages/utils/src/components/eic_upgradable.cairo
+++ b/packages/utils/src/components/eic_upgradable.cairo
@@ -1,0 +1,9 @@
+pub mod eic_upgradable;
+pub mod interface;
+
+pub use eic_upgradable::EICUpgradableComponent;
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod test;

--- a/packages/utils/src/components/eic_upgradable/eic_upgradable.cairo
+++ b/packages/utils/src/components/eic_upgradable/eic_upgradable.cairo
@@ -1,0 +1,50 @@
+/// # EIC Upgradable Component
+///
+/// `replace_class` based upgradability with optional EIC (External Initializer Contract) migration.
+/// It exposes only internal logic and no access control.
+/// It's the developer's responsibilty to restrict calls appropriately.
+#[starknet::component]
+pub mod EICUpgradableComponent {
+    use core::num::traits::Zero;
+    use starknet::syscalls::replace_class_syscall;
+    use starknet::{ClassHash, SyscallResultTrait};
+    use starkware_utils::components::eic_upgradable::interface::{
+        IEICDispatcherTrait, IEICLibraryDispatcher,
+    };
+
+    #[storage]
+    pub struct Storage {}
+
+    #[event]
+    #[derive(Drop, PartialEq, starknet::Event)]
+    pub enum Event {
+        Upgraded: Upgraded,
+    }
+
+    #[derive(Drop, Debug, PartialEq, starknet::Event)]
+    pub struct Upgraded {
+        pub class_hash: ClassHash,
+    }
+
+    pub mod Errors {
+        pub const INVALID_CLASS: felt252 = 'INVALID_CLASS_HASH';
+    }
+
+    #[generate_trait]
+    pub impl InternalImpl<
+        TContractState, +HasComponent<TContractState>, +Drop<TContractState>,
+    > of InternalTrait<TContractState> {
+        fn upgrade(
+            ref self: ComponentState<TContractState>,
+            new_class_hash: ClassHash,
+            eic_data: Option<(ClassHash, Span<felt252>)>,
+        ) {
+            assert(new_class_hash.is_non_zero(), Errors::INVALID_CLASS);
+            if let Some((class_hash, eic_init_data)) = eic_data {
+                IEICLibraryDispatcher { class_hash }.eic_initialize(eic_init_data);
+            }
+            replace_class_syscall(new_class_hash).unwrap_syscall();
+            self.emit(Upgraded { class_hash: new_class_hash });
+        }
+    }
+}

--- a/packages/utils/src/components/eic_upgradable/interface.cairo
+++ b/packages/utils/src/components/eic_upgradable/interface.cairo
@@ -1,0 +1,19 @@
+use starknet::ClassHash;
+
+/// Standard external entrypoint for `EICUpgradableComponent`. Should be implemented by the
+/// contract.
+#[starknet::interface]
+pub trait IEICUpgradable<TContractState> {
+    fn upgrade(
+        ref self: TContractState,
+        new_class_hash: ClassHash,
+        eic_data: Option<(ClassHash, Span<felt252>)>,
+    );
+}
+
+/// External Initializer Contract: `eic_initialize` is called (using library_call) during an upgrade
+/// to perform custom intialization.
+#[starknet::interface]
+pub trait IEIC<TContractState> {
+    fn eic_initialize(ref self: TContractState, data: Span<felt252>);
+}

--- a/packages/utils/src/components/eic_upgradable/mock.cairo
+++ b/packages/utils/src/components/eic_upgradable/mock.cairo
@@ -1,0 +1,85 @@
+/// Minimal versioned interface so tests can observe which class currently backs the contract.
+#[starknet::interface]
+pub trait IMockVersion<TContractState> {
+    fn version(self: @TContractState) -> felt252;
+}
+
+/// Mock embedding `EICUpgradableComponent`. Exposes an unguarded `upgrade` (access control is the
+/// developer's responsibility, out of the component's scope) and reports version `1`.
+#[starknet::contract]
+pub mod EICUpgradableMock {
+    use starknet::ClassHash;
+    use starkware_utils::components::eic_upgradable::EICUpgradableComponent;
+    use starkware_utils::components::eic_upgradable::interface::IEICUpgradable;
+    use super::IMockVersion;
+
+    component!(path: EICUpgradableComponent, storage: upgradable, event: UpgradableEvent);
+
+    impl UpgradableInternal = EICUpgradableComponent::InternalImpl<ContractState>;
+
+    #[storage]
+    pub struct Storage {
+        #[substorage(v0)]
+        pub upgradable: EICUpgradableComponent::Storage,
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    pub enum Event {
+        UpgradableEvent: EICUpgradableComponent::Event,
+    }
+
+    #[abi(embed_v0)]
+    impl EICUpgradableImpl of IEICUpgradable<ContractState> {
+        fn upgrade(
+            ref self: ContractState,
+            new_class_hash: ClassHash,
+            eic_data: Option<(ClassHash, Span<felt252>)>,
+        ) {
+            self.upgradable.upgrade(:new_class_hash, :eic_data);
+        }
+    }
+
+    #[abi(embed_v0)]
+    impl MockVersionImpl of IMockVersion<ContractState> {
+        fn version(self: @ContractState) -> felt252 {
+            1
+        }
+    }
+}
+
+#[starknet::contract]
+pub mod EICMock {
+    use starknet::storage::StoragePointerWriteAccess;
+    use starkware_utils::components::eic_upgradable::interface::IEIC;
+
+    #[storage]
+    struct Storage {
+        eic_marker: felt252,
+    }
+
+    #[abi(embed_v0)]
+    impl EICImpl of IEIC<ContractState> {
+        fn eic_initialize(ref self: ContractState, data: Span<felt252>) {
+            assert(data.len() == 1, 'EIC_INIT_DATA_LEN_MISMATCH');
+            self.eic_marker.write(*data[0]);
+        }
+    }
+}
+
+/// Target class for upgrade tests: a distinct class hash from `EICUpgradableMock` that reports
+/// version `2`, so a test can confirm `replace_class` actually took effect.
+#[starknet::contract]
+pub mod EICUpgradableMockV2 {
+    use super::IMockVersion;
+
+    #[storage]
+    struct Storage {}
+
+    #[abi(embed_v0)]
+    impl MockVersionImpl of IMockVersion<ContractState> {
+        fn version(self: @ContractState) -> felt252 {
+            2
+        }
+    }
+}

--- a/packages/utils/src/components/eic_upgradable/test.cairo
+++ b/packages/utils/src/components/eic_upgradable/test.cairo
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+
+mod EICUpgradableTests {
+    use snforge_std::{
+        ContractClassTrait, DeclareResultTrait, EventSpyAssertionsTrait, declare, load, spy_events,
+    };
+    use starknet::{ClassHash, ContractAddress, SyscallResultTrait};
+    use starkware_utils::components::eic_upgradable::eic_upgradable::EICUpgradableComponent;
+    use starkware_utils::components::eic_upgradable::interface::{
+        IEICUpgradableDispatcher, IEICUpgradableDispatcherTrait,
+    };
+    use starkware_utils::components::eic_upgradable::mock::{
+        EICUpgradableMock, IMockVersionDispatcher, IMockVersionDispatcherTrait,
+    };
+
+    const EIC_MARKER_VALUE: felt252 = 42;
+
+    fn deploy_mock() -> (IEICUpgradableDispatcher, ContractAddress) {
+        let contract = declare("EICUpgradableMock").unwrap_syscall().contract_class();
+        let (address, _) = contract.deploy(@array![]).unwrap_syscall();
+        (IEICUpgradableDispatcher { contract_address: address }, address)
+    }
+
+    fn v2_class_hash() -> ClassHash {
+        *declare("EICUpgradableMockV2").unwrap_syscall().contract_class().class_hash
+    }
+
+    fn eic_class_hash() -> ClassHash {
+        *declare("EICMock").unwrap_syscall().contract_class().class_hash
+    }
+
+    fn version_of(address: ContractAddress) -> felt252 {
+        IMockVersionDispatcher { contract_address: address }.version()
+    }
+
+    #[test]
+    fn test_upgrade_replaces_class_and_emits() {
+        let (dispatcher, address) = deploy_mock();
+        assert!(version_of(address) == 1, "mock should start at version 1");
+        let new_class_hash = v2_class_hash();
+
+        let mut spy = spy_events();
+        dispatcher.upgrade(new_class_hash, Option::None);
+
+        assert!(version_of(address) == 2, "class should have been replaced with v2");
+        spy
+            .assert_emitted(
+                @array![
+                    (
+                        address,
+                        EICUpgradableMock::Event::UpgradableEvent(
+                            EICUpgradableComponent::Event::Upgraded(
+                                EICUpgradableComponent::Upgraded { class_hash: new_class_hash },
+                            ),
+                        ),
+                    ),
+                ],
+            );
+    }
+
+    #[test]
+    fn test_upgrade_runs_eic() {
+        let (dispatcher, address) = deploy_mock();
+        let new_class_hash = v2_class_hash();
+        let eic_class_hash = eic_class_hash();
+
+        dispatcher
+            .upgrade(
+                new_class_hash, Option::Some((eic_class_hash, array![EIC_MARKER_VALUE].span())),
+            );
+
+        // The EIC ran in the mock's storage context, writing the marker slot ...
+        let marker = *load(target: address, storage_address: selector!("eic_marker"), size: 1)
+            .at(0);
+        assert!(marker == EIC_MARKER_VALUE, "EIC should have written the marker slot");
+        // ... and the class was still replaced afterwards.
+        assert!(version_of(address) == 2, "class should have been replaced with v2");
+    }
+
+    #[test]
+    #[should_panic(expected: 'INVALID_CLASS_HASH')]
+    fn test_upgrade_zero_class_hash_reverts() {
+        let (dispatcher, _) = deploy_mock();
+        dispatcher.upgrade(0.try_into().unwrap(), Option::None);
+    }
+
+    #[test]
+    #[should_panic(expected: 'EIC_INIT_DATA_LEN_MISMATCH')]
+    fn test_upgrade_eic_revert_propagates() {
+        let (dispatcher, _) = deploy_mock();
+        let new_class_hash = v2_class_hash();
+        let eic_class_hash = eic_class_hash();
+        // Empty init data trips the EIC's length assert; the whole upgrade must revert.
+        dispatcher.upgrade(new_class_hash, Option::Some((eic_class_hash, array![].span())));
+    }
+}


### PR DESCRIPTION
## Summary

Adds a reusable, `replace_class`-based **upgradability component** with optional **EIC (External Initializer Contract)** migration, under `packages/utils/src/components/eic_upgradable/`.

The logic is extracted from the pattern in `StarknetEth712Account::upgrade` (accounts package) and generalized into a component.

## Design

Modeled on OpenZeppelin's `UpgradeableComponent`:

- **`EICUpgradableComponent`** exposes only an internal `upgrade(new_class_hash, eic_data)` and performs **no access control**. When `eic_data = Some((class_hash, calldata))`, that EIC's `eic_initialize` is `library_call`ed (in the contract's own storage context) *before* the class is replaced, then `Upgraded` is emitted. A zero class hash is rejected.
- **`IEICUpgradable`** is defined but not implemented by the component — the consuming contract implements it, adds its own authorization, and delegates to `self.upgradable.upgrade(...)`.
- **`IEIC`** is the EIC's `eic_initialize` interface used via the library dispatcher.

```cairo
#[abi(embed_v0)]
impl EICUpgradableImpl of IEICUpgradable<ContractState> {
    fn upgrade(ref self: ContractState, new_class_hash: ClassHash, eic_data: Option<(ClassHash, Span<felt252>)>) {
        self.assert_only_self();               // consumer's own access control
        self.upgradable.upgrade(new_class_hash, eic_data);
    }
}
```

## Tests

Integration-style (real `declare`/`replace_class`/`library_call`):

- `test_upgrade_replaces_class_and_emits` — class is swapped (v1→v2) and `Upgraded { class_hash }` is emitted.
- `test_upgrade_runs_eic` — EIC runs in the contract's storage context (marker slot written) and the class is still replaced.
- `test_upgrade_zero_class_hash_reverts` — rejects a zero class hash.
- `test_upgrade_eic_revert_propagates` — an EIC failure aborts the whole upgrade.

No existing code was modified beyond registering the new module in `components.cairo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starkware-starknet-utils/179)
<!-- Reviewable:end -->
